### PR TITLE
パラメータに大文字が指定された場合でも、適切に処理できるように改良

### DIFF
--- a/.github/workflows/run-action.yml
+++ b/.github/workflows/run-action.yml
@@ -61,3 +61,8 @@ jobs:
           global: true
           user: latest-commit
       - run: bash .github/workflows/display.bash
+      - uses: ./
+        with:
+          global: TRUE
+          user: LATEST-COMMIT
+      - run: bash .github/workflows/display.bash

--- a/action.yml
+++ b/action.yml
@@ -30,30 +30,30 @@ runs:
         cd $PATH_DIR
         echo "moved path: $PATH_DIR"
 
-        EMAIL=''
-        NAME=''
+        email=''
+        name=''
         user=${USER,,}
         if [ $user = 'actions-user' ]; then
-          EMAIL='65916846+actions-user@users.noreply.github.com'
-          NAME='actions-user'
+          email='65916846+actions-user@users.noreply.github.com'
+          name='actions-user'
         elif [ $user = 'github-actions' ]; then
-          EMAIL='41898282+github-actions[bot]@users.noreply.github.com'
-          NAME='github-actions[bot]'
+          email='41898282+github-actions[bot]@users.noreply.github.com'
+          name='github-actions[bot]'
         elif [ $user = 'latest-commit' ]; then
-          EMAIL="$(git --no-pager log --format=format:'%ae' -n 1)"
-          NAME="$(git --no-pager log --format=format:'%an' -n 1)"
+          email="$(git --no-pager log --format=format:'%ae' -n 1)"
+          name="$(git --no-pager log --format=format:'%an' -n 1)"
         else
           echo "::error::Please set 'user' to either 'actions-user', 'github-actions' or 'latest-commit'."
           exit 1
         fi
-        echo "name: $NAME"
-        echo "email: $EMAIL"
+        echo "name: $name"
+        echo "email: $email"
 
-        FLAG='--local'
+        flag='--local'
         if [ ${GLOBAL,,} = 'true' ]; then
-          FLAG='--global'
+          flag='--global'
         fi
-        echo "flag: $FLAG"
+        echo "flag: $flag"
 
-        git config $FLAG user.email $EMAIL
-        git config $FLAG user.name $NAME
+        git config $flag user.email $email
+        git config $flag user.name $name

--- a/action.yml
+++ b/action.yml
@@ -32,13 +32,14 @@ runs:
 
         EMAIL=''
         NAME=''
-        if [ $USER = 'actions-user' ]; then
+        user=${USER,,}
+        if [ $user = 'actions-user' ]; then
           EMAIL='65916846+actions-user@users.noreply.github.com'
           NAME='actions-user'
-        elif [ $USER = 'github-actions' ]; then
+        elif [ $user = 'github-actions' ]; then
           EMAIL='41898282+github-actions[bot]@users.noreply.github.com'
           NAME='github-actions[bot]'
-        elif [ $USER = 'latest-commit' ]; then
+        elif [ $user = 'latest-commit' ]; then
           EMAIL="$(git --no-pager log --format=format:'%ae' -n 1)"
           NAME="$(git --no-pager log --format=format:'%an' -n 1)"
         else
@@ -49,7 +50,7 @@ runs:
         echo "email: $EMAIL"
 
         FLAG='--local'
-        if [ $GLOBAL = 'true' ]; then
+        if [ ${GLOBAL,,} = 'true' ]; then
           FLAG='--global'
         fi
         echo "flag: $FLAG"


### PR DESCRIPTION
## 変更内容
* パラメータ `GLOBAL`, `USER` を判定する際、大文字・小文字を区別しないように改良
* 挙動確認用のGitHub Actions Workflow に、大文字を指定したstep を追加
* (リファクタリング) ローカル変数を小文字化
    * 環境変数と見分けを付けやすくするため

