### PR TITLE
小文字への変換ロジックを tr ベースに変更

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
 
         email=''
         name=''
-        user=${USER,,}
+        user=$(echo $USER | tr [A-Z] [a-z])
         if [ $user = 'actions-user' ]; then
           email='65916846+actions-user@users.noreply.github.com'
           name='actions-user'
@@ -50,7 +50,7 @@ runs:
         echo "email: $email"
 
         flag='--local'
-        if [ ${GLOBAL,,} = 'true' ]; then
+        if [ $(echo $GLOBAL | tr [A-Z] [a-z]) = 'true' ]; then
           flag='--global'
         fi
         echo "flag: $flag"


### PR DESCRIPTION
#2 のマージ後、GitHub Actions を実行したところ、macOS で `bad substitution` が発生した。
原因はmacOS のBash は3.x で、Bash 4.x から導入された `${USER,,}` が使えないため。
なので小文字への変換ロジックを `tr` を使ったものに変更した。

* [macOS](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md) -> Bash 3.x
* [Linux](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md), [Windows](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) -> Bash 5.x



参考: https://x.com/raki/status/1784872625019224113