### PR TITLE
#9 の実行エラーの修正

### DIFF
--- a/compiled/index.js
+++ b/compiled/index.js
@@ -26285,8 +26285,8 @@ const git_user_type_1 = __nccwpck_require__(9612);
                 gitCommand = builder.forSpecific(core.getInput('email'), core.getInput('name'));
                 break;
         }
-        await (0, exec_1.exec)(gitCommand.commandUserEmail, undefined, gitCommand.options);
-        await (0, exec_1.exec)(gitCommand.commandUserName, undefined, gitCommand.options);
+        await (0, exec_1.exec)(`"${gitCommand.commandUserEmail}"`, undefined, gitCommand.options);
+        await (0, exec_1.exec)(`"${gitCommand.commandUserName}"`, undefined, gitCommand.options);
     }
     catch (error) {
         if (error instanceof Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,8 @@ import { GitUser, GitUserUtil } from './git-user.type';
         break;
     }
 
-    await exec(gitCommand.commandUserEmail, undefined, gitCommand.options);
-    await exec(gitCommand.commandUserName, undefined, gitCommand.options);
+    await exec(`"${gitCommand.commandUserEmail}"`, undefined, gitCommand.options);
+    await exec(`"${gitCommand.commandUserName}"`, undefined, gitCommand.options);
   } catch (error: unknown) {
     if (error instanceof Error) {
       core.setFailed(error.message);


### PR DESCRIPTION
`latest-commit` を指定した際、下記のコマンドが実行されますが、 `$(git --no-pager log --format=format:'%ae' -n 1)` の部分が評価されていないようでした。
なので、このPR で試しに `"` を追記しました。

> /usr/bin/git config --global user.email $(git --no-pager log --format=format:'%ae' -n 1)