### PR TITLE
コマンド実行の指定方法を調整

### DIFF
--- a/compiled/index.js
+++ b/compiled/index.js
@@ -26177,10 +26177,14 @@ class GitCommandBuilder {
         if (!email || !name) {
             throw Error('Please set email and name.');
         }
-        const flag = this.isGlobal ? '--global' : '--local';
+        const args = [
+            'config',
+            this.isGlobal ? '--global' : '--local',
+        ];
         return {
-            commandUserEmail: `git config ${flag} user.email ${email}`,
-            commandUserName: `git config ${flag} user.name ${name}`,
+            commandLine: 'git',
+            argsUserEmail: [...args, 'user.email', email],
+            argsUserName: [...args, 'user.name', name],
             options: !!this.path ? { cwd: this.path } : undefined,
         };
     }
@@ -26285,8 +26289,8 @@ const git_user_type_1 = __nccwpck_require__(9612);
                 gitCommand = builder.forSpecific(core.getInput('email'), core.getInput('name'));
                 break;
         }
-        await (0, exec_1.exec)(`"${gitCommand.commandUserEmail}"`, undefined, gitCommand.options);
-        await (0, exec_1.exec)(`"${gitCommand.commandUserName}"`, undefined, gitCommand.options);
+        await (0, exec_1.exec)(gitCommand.commandLine, gitCommand.argsUserEmail, gitCommand.options);
+        await (0, exec_1.exec)(gitCommand.commandLine, gitCommand.argsUserName, gitCommand.options);
     }
     catch (error) {
         if (error instanceof Error) {

--- a/src/git-command.test.ts
+++ b/src/git-command.test.ts
@@ -4,12 +4,12 @@ import { GitCommandBuilder } from './git-command';
 
 test('GitCommandBuilder.isGlobal', () => {
   const globalCommand = new GitCommandBuilder(true, '').forActionsUser();
-  assert.ok(globalCommand.commandUserEmail.includes('--global'));
-  assert.ok(globalCommand.commandUserName.includes('--global'));
+  assert.ok(globalCommand.argsUserEmail.includes('--global'));
+  assert.ok(globalCommand.argsUserName.includes('--global'));
 
   const localCommand = new GitCommandBuilder(false, '').forActionsUser();
-  assert.ok(localCommand.commandUserEmail.includes('--local'));
-  assert.ok(localCommand.commandUserName.includes('--local'));
+  assert.ok(localCommand.argsUserEmail.includes('--local'));
+  assert.ok(localCommand.argsUserName.includes('--local'));
 });
 
 test('GitCommandBuilder.path', () => {

--- a/src/git-command.ts
+++ b/src/git-command.ts
@@ -2,8 +2,9 @@
  * (型エイリアス) 実行するGit コマンド情報
  */
 export type GitCommand = {
-  commandUserEmail: string,
-  commandUserName: string,
+  commandLine: string,
+  argsUserEmail: string[],
+  argsUserName: string[],
   options?: { cwd?: string },
 };
 
@@ -41,15 +42,19 @@ export class GitCommandBuilder {
     );
   }
 
-  public forSpecific(email: string, name: string) {
+  public forSpecific(email: string, name: string): GitCommand {
     if (!email || !name) {
       throw Error('Please set email and name.');
     }
 
-    const flag = this.isGlobal ? '--global' : '--local';
+    const args = [
+      'config',
+      this.isGlobal ? '--global' : '--local',
+    ];
     return {
-      commandUserEmail: `git config ${flag} user.email ${email}`,
-      commandUserName: `git config ${flag} user.name ${name}`,
+      commandLine: 'git',
+      argsUserEmail: [...args, 'user.email', email],
+      argsUserName: [...args, 'user.name', name],
       options: !!this.path ? { cwd: this.path } : undefined,
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,8 @@ import { GitUser, GitUserUtil } from './git-user.type';
         break;
     }
 
-    await exec(`"${gitCommand.commandUserEmail}"`, undefined, gitCommand.options);
-    await exec(`"${gitCommand.commandUserName}"`, undefined, gitCommand.options);
+    await exec(gitCommand.commandLine, gitCommand.argsUserEmail, gitCommand.options);
+    await exec(gitCommand.commandLine, gitCommand.argsUserName, gitCommand.options);
   } catch (error: unknown) {
     if (error instanceof Error) {
       core.setFailed(error.message);


### PR DESCRIPTION
#10 で実行するコマンドに `"` を囲ってみたところ、全て失敗するようになったので、コマンド実行の指定方法を変更した。

> Error: Unable to locate executable file: git config --local user.email 41898282+github-actions[bot]@users.noreply.github.com. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.