### PR TITLE
Git ログからユーザー特定するコマンドを " での囲いを追加

### DIFF
--- a/compiled/index.js
+++ b/compiled/index.js
@@ -26171,7 +26171,7 @@ class GitCommandBuilder {
         return this.forSpecific('41898282+github-actions[bot]@users.noreply.github.com', 'github-actions[bot]');
     }
     forLatestCommit() {
-        return this.forSpecific(`$(git --no-pager log --format=format:'%ae' -n 1)`, `$(git --no-pager log --format=format:'%an' -n 1)`);
+        return this.forSpecific(`"$(git --no-pager log --format=format:'%ae' -n 1)"`, `"$(git --no-pager log --format=format:'%an' -n 1)"`);
     }
     forSpecific(email, name) {
         if (!email || !name) {

--- a/src/git-command.ts
+++ b/src/git-command.ts
@@ -37,8 +37,8 @@ export class GitCommandBuilder {
 
   public forLatestCommit() {
     return this.forSpecific(
-      `$(git --no-pager log --format=format:'%ae' -n 1)`,
-      `$(git --no-pager log --format=format:'%an' -n 1)`,
+      `"$(git --no-pager log --format=format:'%ae' -n 1)"`,
+      `"$(git --no-pager log --format=format:'%an' -n 1)"`,
     );
   }
 


### PR DESCRIPTION
#11 で正常実行できるようになったものの、引数に指定したコマンドが実行されなかったので、試しに `"` の囲いを追加した。