### PR TITLE
リリースフローの再整備(その２)

### DIFF
--- a/.github/workflows/140-create-version-pr.yml
+++ b/.github/workflows/140-create-version-pr.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Create a pull request
         env:
+          ASSIGNEE: tshion
           BASE: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.meta.outputs.version }}
@@ -77,4 +78,4 @@ jobs:
           git commit --message "$message"
           git push --set-upstream origin "$branch"
 
-          gh pr create --assignee "@me" --base "$BASE" --title "$message" --body ""
+          gh pr create --assignee "$ASSIGNEE" --base "$BASE" --title "$message" --body ""

--- a/.github/workflows/160a-test-action.yml
+++ b/.github/workflows/160a-test-action.yml
@@ -15,6 +15,9 @@ jobs:
     outputs:
       configs: ${{ steps.result.outputs.configs }}
     steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+
       - id: result
         run: |
           ruby ./.github/scripts/create-test-config.rb


### PR DESCRIPTION
#22 のマージ後に、GitHub Actions を実行したところ、下記のエラーが発生したので、その修正を行なった。

* 140: おそらくgit user にGitHub Actions を設定し、 `gh release create` で `@me` を指定したためエラーが発生した
    > GraphQL: Could not resolve to a User with the login of 'github-actions[bot]'. (u000)
* 160a: checkout が漏れていた
    > ruby: No such file or directory -- ./.github/scripts/create-test-config.rb (LoadError)