### PR TITLE
リリースフローの再整備(その３)

### DIFF
--- a/.github/workflows/140-create-version-pr.yml
+++ b/.github/workflows/140-create-version-pr.yml
@@ -24,6 +24,7 @@ jobs:
   create-pr:
     if: ${{ github.ref_type == 'branch' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/160-create-release-pr.yml
+++ b/.github/workflows/160-create-release-pr.yml
@@ -16,6 +16,7 @@ jobs:
   create-pr:
     needs: test-action
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/160a-test-action.yml
+++ b/.github/workflows/160a-test-action.yml
@@ -47,13 +47,13 @@ jobs:
           path: ./main/
           user: actions-user
       - working-directory: ./main/
-        run: bash ./.github/workflows/scripts/display.bash
+        run: bash ../tools/.github/workflows/scripts/display.bash
 
       - uses: ./
         with:
           global: TRUE
           user: ACTIONS-USER
-      - run: bash ./.github/workflows/scripts/display.bash
+      - run: bash ./tools/.github/workflows/scripts/display.bash
 
 
   github-actions:
@@ -78,13 +78,13 @@ jobs:
           path: ./main/
           user: github-actions
       - working-directory: ./main/
-        run: bash ./.github/workflows/scripts/display.bash
+        run: bash ../tools/.github/workflows/scripts/display.bash
 
       - uses: ./
         with:
           global: TRUE
           user: GITHUB-ACTIONS
-      - run: bash ./.github/workflows/scripts/display.bash
+      - run: bash ./tools/.github/workflows/scripts/display.bash
 
 
   latest-commit:
@@ -109,13 +109,13 @@ jobs:
           path: ./main/
           user: latest-commit
       - working-directory: ./main/
-        run: bash ./.github/workflows/scripts/display.bash
+        run: bash ../tools/.github/workflows/scripts/display.bash
 
       - uses: ./
         with:
           global: TRUE
           user: LATEST-COMMIT
-      - run: bash ./.github/workflows/scripts/display.bash
+      - run: bash ./tools/.github/workflows/scripts/display.bash
 
 
   specific:
@@ -142,7 +142,7 @@ jobs:
           email: hoge@example.com
           name: hoge
       - working-directory: ./main/
-        run: bash ./.github/workflows/scripts/display.bash
+        run: bash ../tools/.github/workflows/scripts/display.bash
 
       - uses: ./
         with:
@@ -150,4 +150,4 @@ jobs:
           user: SPECIFIC
           email: hoge@example.com
           name: hoge
-      - run: bash ./.github/workflows/scripts/display.bash
+      - run: bash ./tools/.github/workflows/scripts/display.bash

--- a/.github/workflows/160a-test-action.yml
+++ b/.github/workflows/160a-test-action.yml
@@ -29,6 +29,7 @@ jobs:
     needs: config
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.configs) }}
+      max-parallel: 1
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:
@@ -60,6 +61,7 @@ jobs:
     needs: config
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.configs) }}
+      max-parallel: 1
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:
@@ -91,6 +93,7 @@ jobs:
     needs: config
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.configs) }}
+      max-parallel: 1
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:
@@ -122,6 +125,7 @@ jobs:
     needs: config
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.configs) }}
+      max-parallel: 1
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:

--- a/.github/workflows/160a-test-action.yml
+++ b/.github/workflows/160a-test-action.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   config:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     outputs:
       configs: ${{ steps.result.outputs.configs }}
     steps:
@@ -29,6 +30,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.configs) }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v4
@@ -59,6 +61,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.configs) }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v4
@@ -89,6 +92,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.configs) }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v4
@@ -119,6 +123,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.configs) }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v4

--- a/.github/workflows/180-release-preparation.yml
+++ b/.github/workflows/180-release-preparation.yml
@@ -15,6 +15,7 @@ jobs:
   preparation:
     if: ${{ github.ref_type == 'branch' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
#23 のマージ後に、GitHub Actions を実行したところ、下記のエラーが発生したので、その修正を行なった。

* 160a: スクリプトのパス指定ミス
    > bash: ./.github/workflows/scripts/display.bash: No such file or directory

それ以外に下記の設定を追加した。

* Job のタイムアウト時間の設定
* 160a でmatrix を使っている箇所の同時実行数の制限を追加