### PR TITLE
リリースフローの再整備(その５)

### DIFF
--- a/.github/workflows/160a-test-action.yml
+++ b/.github/workflows/160a-test-action.yml
@@ -50,7 +50,7 @@ jobs:
       - working-directory: ./main/
         run: bash ../tools/.github/scripts/display.bash
 
-      - uses: ./
+      - uses: ./tools/
         with:
           global: TRUE
           user: ACTIONS-USER
@@ -82,7 +82,7 @@ jobs:
       - working-directory: ./main/
         run: bash ../tools/.github/scripts/display.bash
 
-      - uses: ./
+      - uses: ./tools/
         with:
           global: TRUE
           user: GITHUB-ACTIONS
@@ -114,7 +114,7 @@ jobs:
       - working-directory: ./main/
         run: bash ../tools/.github/scripts/display.bash
 
-      - uses: ./
+      - uses: ./tools/
         with:
           global: TRUE
           user: LATEST-COMMIT
@@ -148,7 +148,7 @@ jobs:
       - working-directory: ./main/
         run: bash ../tools/.github/scripts/display.bash
 
-      - uses: ./
+      - uses: ./tools/
         with:
           global: TRUE
           user: SPECIFIC


### PR DESCRIPTION
#27 のマージ後に、GitHub Actions を実行したところ、下記のエラーが発生したので、その修正を行なった。

* 160a: アクションのパス指定ミス
    > Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/apply-git-user/apply-git-user'. Did you forget to run actions/checkout before running your local action?