### PR TITLE
リリースフローの再整備(その６)

### DIFF
--- a/.github/workflows/160a-test-action.yml
+++ b/.github/workflows/160a-test-action.yml
@@ -116,6 +116,7 @@ jobs:
 
       - uses: ./tools/
         with:
+          path: ./tools/
           global: TRUE
           user: LATEST-COMMIT
       - run: bash ./tools/.github/scripts/display.bash


### PR DESCRIPTION
#28 のマージ後に、GitHub Actions を実行したところ、下記のエラーが発生したので、その修正を行なった。

* 160a: アクションのパス指定ミス
    > fatal: not a git repository (or any of the parent directories): .git