### PR TITLE
リリースフローの再整備(その７)

### DIFF
--- a/.github/workflows/160-create-release-pr.yml
+++ b/.github/workflows/160-create-release-pr.yml
@@ -39,8 +39,9 @@ jobs:
 
       - name: Create pull request
         env:
+          ASSIGNEE: tshion
           BODY: "result: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GH_TOKEN: ${{ github.token }}
           TITLE: "Merge ${{ steps.meta.outputs.name }}"
         run: |
-          gh pr create --assignee "@me" --base released --title "$TITLE" --body "$BODY"
+          gh pr create --assignee "$ASSIGNEE" --base released --title "$TITLE" --body "$BODY"


### PR DESCRIPTION
#29 のマージ後に、GitHub Actions を実行したところ、下記のエラーが発生したので、その修正を行なった。

* 160: git user にGitHub Actions を設定し、 `gh release create` で `@me` を指定してしまった (#23)
    > GraphQL: Could not resolve to a User with the login of 'github-actions[bot]'. (u000)