### PR TITLE
リリースフローの再整備(その８)

### DIFF
--- a/.github/workflows/160-create-release-pr.yml
+++ b/.github/workflows/160-create-release-pr.yml
@@ -42,6 +42,6 @@ jobs:
           ASSIGNEE: tshion
           BODY: "result: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GH_TOKEN: ${{ github.token }}
-          TITLE: "Merge ${{ steps.meta.outputs.name }}"
+          TITLE: "Merge ${{ steps.meta.outputs.version }}"
         run: |
           gh pr create --assignee "$ASSIGNEE" --base released --title "$TITLE" --body "$BODY"


### PR DESCRIPTION
#31 のマージ後に、GitHub Actions を実行したところ、160 で生成したPull Request のタイトルにバージョン情報が表示されていなかったので修正した。

https://github.com/tshion/apply-git-user/pull/32