### PR TITLE
【GitHub Actions】#114 の修正

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -58,6 +58,12 @@ jobs:
         with:
           tag: ${{ steps.meta.outputs.version }}
 
+      # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+      - name: Set up git user
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
       - name: Create a working git branch
         env:
           BRANCH: ${{ steps.meta.outputs.branch }}
@@ -71,12 +77,6 @@ jobs:
       - run: npm test
 
       - run: npm run build
-
-      # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-      - name: Set up git user
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
 
       - name: git commit & push
         env:


### PR DESCRIPTION
* Git ユーザー設定タイミングの調整

#114 マージ後にGitHub Actions を実行したところ、下記エラーとなったため。

``` log
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az1278-[18](https://github.com/tshion/apply-git-user/actions/runs/15443349938/job/43466353485#step:6:19)3.queh1xzsn3aexkx5dk5ryuekfg.dx.internal.cloudapp.net>) not allowed
Error: Process completed with exit code 128.
```